### PR TITLE
fix wrong build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Build steps:
 ```shell
 # clone this repo and all the submodules
 # in the top-level folder
-$ git submodule update --init
+$ git submodule update --init --recursive
 
 $ mkdir build
 $ cd build


### PR DESCRIPTION
When installing submodules need to add `--recursive` to update recursively.

```diff
- git submodule update --init
+ git submodule update --init --recursive
```

Otherwise, an error will be reported when running `cmake`:

```bash
CMake Error at canokey-core/CMakeLists.txt:29 (add_subdirectory):
  The source directory

    canokey-nrf52/canokey-core/canokey-crypto

  does not contain a CMakeLists.txt file.
```