### PR TITLE
add makerdiary/nrf52840_usb_dongle.h config for correct pin ocnnection

### DIFF
--- a/config/board_selection.h
+++ b/config/board_selection.h
@@ -8,7 +8,9 @@
 
 //--------------------------------------------------------------------+
 // MakerDiary M.2 DOCK
-#define OPT_BOARD_MAKERDIARY_M2_DOCK    1
+#define OPT_BOARD_MAKERDIARY_M2_DOCK    1           
+// MakerDiary NRF52840 USB DONGLE
+#define OPT_BOARD_MAKERDIARY_NRF52840_USB_DONGLE    3
 
 // nRF52840 Dongle (aka PCA10059)
 #define OPT_BOARD_NRF52840_DONGLE       2
@@ -20,6 +22,8 @@
     #include "boards/nordic/pca10059.h"
 #elif CFG_BOARD == OPT_BOARD_MAKERDIARY_M2_DOCK
     #include "boards/makerdiary/m2_dock.h"
+#elif CFG_BOARD == OPT_BOARD_MAKERDIARY_NRF52840_USB_DONGLE
+    #include "boards/makerdiary/nrf52840_usb_dongle.h"
 #else
     #error "No board selected, please select your board in CMakeLists.txt"
 #endif

--- a/config/boards/makerdiary/nrf52840_usb_dongle.h
+++ b/config/boards/makerdiary/nrf52840_usb_dongle.h
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2017 - 2021, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef NRF52840_USB_DONGLE
+#define NRF52840_USB_DONGLE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// LED definitions for 
+// Each LED color is considered a separate LED
+#define LEDS_NUMBER    4
+
+#define LED1_G         NRF_GPIO_PIN_MAP(0,22)
+#define LED2_R         NRF_GPIO_PIN_MAP(0,23)
+#define LED2_G         NRF_GPIO_PIN_MAP(0,22)
+#define LED2_B         NRF_GPIO_PIN_MAP(0,24)
+
+#define LED_1          LED1_G
+#define LED_2          LED2_R
+#define LED_3          LED2_G
+#define LED_4          LED2_B
+
+#define LEDS_ACTIVE_STATE 0
+
+#define LEDS_LIST { LED_1, LED_2, LED_3, LED_4 }
+
+#define LEDS_INV_MASK  LEDS_MASK
+
+#define BSP_LED_0      LED_1
+#define BSP_LED_1      LED_2
+#define BSP_LED_2      LED_3
+#define BSP_LED_3      LED_4
+
+// There is only one button on board 
+// and it is used for the application
+
+#define BUTTONS_NUMBER 1
+
+#define BUTTON_1       NRF_GPIO_PIN_MAP(0,18)
+#define BUTTON_PULL    NRF_GPIO_PIN_PULLUP
+
+#define BUTTONS_ACTIVE_STATE 0
+
+#define BUTTONS_LIST { BUTTON_1 }
+
+#define BSP_BUTTON_0   BUTTON_1
+
+#define BSP_SELF_PINRESET_PIN NRF_GPIO_PIN_MAP(0,16)
+
+#define RX_PIN_NUMBER  NRF_GPIO_PIN_MAP(1,10)
+#define TX_PIN_NUMBER  NRF_GPIO_PIN_MAP(1,13)
+#define CTS_PIN_NUMBER NRF_GPIO_PIN_MAP(1,15)
+#define RTS_PIN_NUMBER NRF_GPIO_PIN_MAP(0,2)
+#define HWFC           false
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NRF52840_USB_DONGLE


### PR DESCRIPTION
a part of solution about [issue/4](https://github.com/canokeys/canokey-nrf52/issues/4)